### PR TITLE
Fix problems with the card veil

### DIFF
--- a/src/containers/Card/card.js
+++ b/src/containers/Card/card.js
@@ -11,9 +11,15 @@ class Card extends Component {
     showVeil: false,
   };
 
-  onToggleVeil = () => {
+  onShowVeil = () => {
     this.setState({
-      showVeil: !this.state.showVeil,
+      showVeil: true,
+    });
+  };
+
+  onHideVeil = () => {
+    this.setState({
+      showVeil: false,
     });
   };
 
@@ -31,7 +37,7 @@ class Card extends Component {
     const slicedDescription = this._addDots(description);
 
     return (
-      <Wrapper onMouseEnter={this.onToggleVeil} onMouseLeave={this.onToggleVeil}>
+      <Wrapper onMouseEnter={this.onShowVeil} onMouseLeave={this.onHideVeil}>
         <Title backgroundImage={url}>{title}</Title>
         <div>
           <p>{slicedDescription}</p>


### PR DESCRIPTION
# Background

If you delete one card and the next one is placed in the eliminated position, the card that right now is over the mouse, don't response properly to the mouse events to show the veil

# Goal

Correct the previous commented behaviour

# Implementation

When before just have onToggleModal, right now we have onShowModal and onHideModal

# Checklist

- [x] The PR relates to _only_ one subject with a clear title.
- [x] I have performed a self-review of my own code
- [x] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My code is readable by someone else, and I commented the hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
